### PR TITLE
Various missed infos, clarifications

### DIFF
--- a/scripting/nodes/events-inventory/register-on-weapon-no-ammo.md
+++ b/scripting/nodes/events-inventory/register-on-weapon-no-ammo.md
@@ -1,4 +1,9 @@
 # Register On Weapon No Ammo
+
+{% hint style="important" %}
+This node was originally created to cover instances where weapons created using **Spawn Mode Object** might not trigger the **On Weapon No Ammo** Event, but they do, so it's currently not needed.
+{% endhint %}
+
 ![](../../../.gitbook/assets/register-on-weapon-no-ammo.png)
 ## Description
 (Registers a weapon so an) Event executes when the given _Weapon_ runs out of ammo.  
@@ -14,11 +19,9 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 ## Outputs
 | Output | Type | Description |
 |------------------|------------------|--------------------------------------------------------------|
-| Player | Object | Which player is holding weapon when it runs out of ammo.|
-| Weapon | Object | The weapon that has run out of ammo.|
+| Player | Object | Deprecated. |
+| Weapon | Object | Deprecated. |
 
-## Notes
-This node was originally created to cover instances where weapons created using **Spawn Mode Object** might not trigger the **On Weapon No Ammo** Event, but they do, so it's currently not needed.
 
 \
 \

--- a/scripting/nodes/events-inventory/register-on-weapon-pickup.md
+++ b/scripting/nodes/events-inventory/register-on-weapon-pickup.md
@@ -1,4 +1,9 @@
 # Register On Weapon Pickup
+
+{% hint style="important" %}
+This node was originally created to cover instances where weapons created using **Spawn Mode Object** might not trigger the **On Weapon Pickup** Event, but they do, so it's currently not needed.
+{% endhint %}
+
 ![](../../../.gitbook/assets/register-on-weapon-pickup.png)
 ## Description
 (Registers a weapon so an) Event executes when a player explicitly picks up the given _Weapon_.  
@@ -14,11 +19,9 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 ## Outputs
 | Output | Type | Description |
 |------------------|------------------|--------------------------------------------------------------|
-| Acquiring Player | Player | Which player picked up the weapon.|
-| Pickup Position | Vector3 | Location weapon was at when it was picked up.|
+| Acquiring Player | Player | Deprecated. |
+| Pickup Position | Vector3 | Deprecated. |
 
-## Notes
-This node was originally created to cover instances where weapons created using **Spawn Mode Object** might not trigger the **On Weapon Pickup** Event, but they do, so it's currently not needed.
 
 \
 \

--- a/scripting/nodes/events-players/on-custom-input-hold.md
+++ b/scripting/nodes/events-players/on-custom-input-hold.md
@@ -14,7 +14,7 @@ Nodes fall into two basic categories: Data and Execution. This node listens for 
 ## Outputs
 | Output | Type | Description |
 |------------------|------------------|--------------------------------------------------------------|
-| Player | Player | The player who is holding custom input. |
+| Player | Object | The player who is holding custom input. |
 
 \
 \

--- a/scripting/nodes/events/on-registered-object-exited-kill-volume.md
+++ b/scripting/nodes/events/on-registered-object-exited-kill-volume.md
@@ -14,7 +14,7 @@ Nodes fall into two basic categories: Data and Execution. This Execution node fi
 ## Outputs
 | Output           | Type             | Description												     |
 |------------------|------------------|--------------------------------------------------------------|
-| Object | Object  | The Object that was detected entering a Kill Volume.  |
+| Object | Object  | The Object that was detected exiting a Kill Volume.  |
 
 \
 \

--- a/scripting/nodes/objects/get-object-team.md
+++ b/scripting/nodes/objects/get-object-team.md
@@ -15,6 +15,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 | Output | Type | Description |
 |------------------|------------------|--------------------------------------------------------------|
 | Team | Team | Team of the object. |
+| Is Neutral | Boolean | Outputs TRUE if object's Team is neutral, FALSE if not. |
 
 \
 \

--- a/scripting/nodes/ui/print-ui-message-to-killfeed-for-player.md
+++ b/scripting/nodes/ui/print-ui-message-to-killfeed-for-player.md
@@ -10,7 +10,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 | Input | Type | Required | Description |
 |------------------|------------------|----------|--------------------------------------------------------------|
 | Player | Player | Yes | Which player to print message for. |
-| Message | String | Yes | A Message node plugs in here to display for player. |
+| Message | String | Yes | Any message output pin plugs in here to display for player. |
 
 ## Outputs
 | Output | Type | Description |

--- a/scripting/nodes/ui/print-ui-message-to-killfeed-for-team.md
+++ b/scripting/nodes/ui/print-ui-message-to-killfeed-for-team.md
@@ -10,7 +10,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 | Input | Type | Required | Description |
 |------------------|------------------|----------|--------------------------------------------------------------|
 | Team | Team | Yes | Which team to print message for. |
-| Message | String | Yes | A Message node plugs in here to display for player. |
+| Message | String | Yes | Any message output pin plugs in here to display for player. |
 
 ## Outputs
 | Output | Type | Description |

--- a/scripting/nodes/ui/print-ui-message-to-killfeed.md
+++ b/scripting/nodes/ui/print-ui-message-to-killfeed.md
@@ -9,7 +9,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 ## Inputs
 | Input | Type | Required | Description |
 |------------------|------------------|----------|--------------------------------------------------------------|
-| Message | String | Yes | A Create Message node plugs in here to display for player. |
+| Message | String | Yes | Any message output pin plugs in here to display for player. |
 
 ## Outputs
 | Output | Type | Description |

--- a/scripting/nodes/ui/push-splash-to-player.md
+++ b/scripting/nodes/ui/push-splash-to-player.md
@@ -11,7 +11,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 |------------------|------------------|----------|--------------------------------------------------------------|
 | Player | Player | Yes | Which player to push splash for. |
 | Duration In Seconds | Number | No | How many seconds splash will display for (2.5 minimum). |
-| Message | String | Yes | A Create Message node plugs in here to display for player. |
+| Message | String | Yes | Any message output pin plugs in here to display for player. |
 
 ## Outputs
 | Output | Type | Description |

--- a/scripting/nodes/ui/set-menu-item-property-description.md
+++ b/scripting/nodes/ui/set-menu-item-property-description.md
@@ -10,7 +10,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 | Input | Type | Required | Description |
 |------------------|------------------|----------|--------------------------------------------------------------|
 | Menu Item | Menu Item | Yes | Which menu item to set property of.|
-| Message | String | Yes | What message to use to set as the property. |
+| Message | String | Yes | Any message output pin plugs in here. |
 
 ## Outputs
 | Output | Type | Description |

--- a/scripting/nodes/ui/set-menu-item-property-title.md
+++ b/scripting/nodes/ui/set-menu-item-property-title.md
@@ -10,7 +10,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 | Input | Type | Required | Description |
 |------------------|------------------|----------|--------------------------------------------------------------|
 | Menu Item | Menu Item | Yes | Which menu item to set property of. |
-| Message | String | Yes | What message to use to set as the property. |
+| Message | String | Yes | Any message output pin plugs in here. |
 
 ## Outputs
 | Output | Type | Description |

--- a/scripting/nodes/variables-advanced/equipment-type-variable.md
+++ b/scripting/nodes/variables-advanced/equipment-type-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Equipment Type Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Equipment Type Variable

--- a/scripting/nodes/variables-advanced/grenade-type-variable.md
+++ b/scripting/nodes/variables-advanced/grenade-type-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Grenade Type Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Grenade Type Variable

--- a/scripting/nodes/variables-advanced/menu-item-variable.md
+++ b/scripting/nodes/variables-advanced/menu-item-variable.md
@@ -30,7 +30,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Menu Item Variable
@@ -56,7 +56,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Menu Item Variable

--- a/scripting/nodes/variables-advanced/menu-variable.md
+++ b/scripting/nodes/variables-advanced/menu-variable.md
@@ -19,7 +19,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 | Input         | Type   | Required | Description |
 | ------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Identifier | String | Yes | The custom string id for this variable. |
-| Initial Value | String | No | What the variable holds when the game starts. |
+| Initial Value | Menu | No | What the variable holds when the game starts. |
 | Scope | Scope | Yes | Local scope can only be accessed within the same script brain. Global and Object can be accessed by any script brain. Object scoped variables use the Object pin, to associate the variable with an object in the game. |
 
 ## Outputs
@@ -30,7 +30,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Menu Variable
@@ -57,7 +57,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Menu Variable
@@ -73,7 +73,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 | Input      | Type   | Required | Description                                                          |
 | ---------- | ------ | -------- | -------------------------------------------------------------------- |
 | Identifier | String | Yes  | The custom string id for this variable. |
-| Value | Menu | Yes | The Menu for this variable. |
+| Value | Menu | Yes | The Menu that is being set for this variable. |
 | Scope | Scope  | Yes | Must match scope of declared variable with the same identifier. |
 | Object | Object | No | Used to associate variable with an object when Object scope is used. |
 

--- a/scripting/nodes/variables-advanced/number-variable.md
+++ b/scripting/nodes/variables-advanced/number-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Number Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Number Variable

--- a/scripting/nodes/variables-advanced/object-list-variable.md
+++ b/scripting/nodes/variables-advanced/object-list-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Object List Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Object List Variable

--- a/scripting/nodes/variables-advanced/object-variable.md
+++ b/scripting/nodes/variables-advanced/object-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Object Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Object Variable

--- a/scripting/nodes/variables-advanced/squad-definition-variable.md
+++ b/scripting/nodes/variables-advanced/squad-definition-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Squad Definition Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Squad Definition Variable

--- a/scripting/nodes/variables-advanced/squad-variable.md
+++ b/scripting/nodes/variables-advanced/squad-variable.md
@@ -32,9 +32,10 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 | ------ | ---- | ----------- |
 | (none) |      |             |
 
+
 ***
 
-\
+***
 
 
 ## Get Squad Variable
@@ -65,7 +66,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Squad Variable

--- a/scripting/nodes/variables-advanced/string-variable.md
+++ b/scripting/nodes/variables-advanced/string-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get String Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set String Variable

--- a/scripting/nodes/variables-advanced/team-variable.md
+++ b/scripting/nodes/variables-advanced/team-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Team Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Team Variable

--- a/scripting/nodes/variables-advanced/ui-message-variable.md
+++ b/scripting/nodes/variables-advanced/ui-message-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get UI Message Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set UI Message Variable

--- a/scripting/nodes/variables-advanced/user-label-variable.md
+++ b/scripting/nodes/variables-advanced/user-label-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get User Label Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set User Label Variable

--- a/scripting/nodes/variables-advanced/vector3-variable.md
+++ b/scripting/nodes/variables-advanced/vector3-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Vector3 Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Vector3 Variable

--- a/scripting/nodes/variables-advanced/vehicle-type-variable.md
+++ b/scripting/nodes/variables-advanced/vehicle-type-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Vehicle Type Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Vehicle Type Variable

--- a/scripting/nodes/variables-advanced/wave-manager-variable.md
+++ b/scripting/nodes/variables-advanced/wave-manager-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Wave Manager Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Wave Manager Variable

--- a/scripting/nodes/variables-advanced/wave-variable.md
+++ b/scripting/nodes/variables-advanced/wave-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Wave Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Wave Variable

--- a/scripting/nodes/variables-advanced/weapon-type-variable.md
+++ b/scripting/nodes/variables-advanced/weapon-type-variable.md
@@ -34,7 +34,7 @@ Nodes fall into two basic categories: Data and Execution. This node Executes a f
 
 ***
 
-\
+***
 
 
 ## Get Weapon Type Variable
@@ -65,7 +65,7 @@ Nodes fall into two basic categories: Data and Execution. This node supplies Dat
 
 ***
 
-\
+***
 
 
 ## Set Weapon Type Variable


### PR DESCRIPTION
* Variable pages had a back slash visible that created a line break in VSC but not on website
* Message input descriptions referred to using a message create system, but now there are far more ways to pass forward messages, so wording was changed to any message output pin
* Get Object Team had image updated, but new pin wasn't in the pin descriptions table
* Register On Weapon No Ammo and Register On Weapon Pickup had their "notes" moved to the top of the page, so users are aware that these nodes are not needed. The false descriptions of their output nodes have been changed to "deprecated".