### PR TITLE
Add article: "Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1184,6 +1184,7 @@
     * [Applying Inaccessible Object Properties](knowledge/forge/exploits/applying-inaccessible-object-properties.md)
 * [Scripting](knowledge/scripting/README.md)
   * [Guides and Info](knowledge/scripting/guides-and-info/README.md)
+    * ["Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller](knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md)
     * [Creating an Equipment Object Reference with Mode Scripting](knowledge/scripting/guides-and-info/creating-an-equipment-object-reference-with-mode-scripting.md)
     * [Patterns](knowledge/scripting/guides-and-info/patterns/README.md)
       * [Telefragging](knowledge/scripting/guides-and-info/patterns/telefragging.md)

--- a/knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md
+++ b/knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md
@@ -1,0 +1,41 @@
+---
+description: >-
+  The Killed Unit Position pin in the On AI Unit Killed node outputs a
+  Vector3 that is 10x smaller than the expected Forge position.
+---
+
+# "Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller
+
+<figure><img src="../../../.gitbook/assets/cover-tsg-placeholder.jpg" alt="Cover image"><figcaption></figcaption></figure>
+
+The `On AI Unit Killed` node provides a `Killed Unit Position` pin intended to return the location where a unit died. However, the Vector3 output from this pin is scaled incorrectly relative to standard Forge coordinates.
+
+## Vector3 Scaling Discrepancy
+
+The `Killed Unit Position` pin outputs a [Vector3](../../../scripting/nodes/variables-basic/vector3.md) that is 10x smaller than the actual position used by Forge. This discrepancy means that using the raw output directly for spatial logic will result in coordinates being positioned near the map origin rather than at the unit's death site.
+
+### Correcting the Output
+
+To obtain the correct position, the Vector3 from the `Killed Unit Position` pin must be processed through a `Scale Vector` node. Using a scalar value of `10.00` will scale the vector back to the intended Forge coordinate system.
+
+<figure><img src="../../../.gitbook/assets/2025-12-17_HaloInfinite-d8mD.png" alt="Node graph demonstration"><figcaption><p>The node graph shows the On AI Unit Killed pin being passed into a Scale Vector node with a 10.00 scalar to correct the position.</p></figcaption></figure>
+
+## Implementation Requirements
+
+When scripting events that rely on the location of a unit's death—such as spawning effects, setting object positions, or triggering proximity logic—this scaling step is required.
+
+{% hint style="info" %}
+To ensure accurate positioning, the `Killed Unit Position` pin should be fed into a `Scale Vector` node with a `10.00` scalar.
+{% endhint %}
+
+<figure><img src="../../../.gitbook/assets/2025-12-17_HaloInfinite-lcEr.jpg" alt="In-game debug view"><figcaption><p>Debug text in-game illustrates the difference between the original death position and the scaled value.</p></figcaption></figure>
+
+***
+
+## Source Data
+
+* Discord thread: ["Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller](https://discord.com/channels/220766496635224065/1450874812405645402/1450874812405645402)
+
+#### <mark style="color:green;">Contributors</mark>
+
+Okom


### PR DESCRIPTION
Article draft generated by The Archivist:

- Article path: [knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md](https://github.com/The-Scripters-Guild/ForgeWiki/pull/114/changes/3d2e98ec2cd3d518c7fe90bbae547b20b217f2c2#diff-2a9423dd63646ed936d079d59273d0811b5caebe477f238838eca492442907e3)
- Source thread: ["Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller](https://discord.com/channels/220766496635224065/1450874812405645402/1450874812405645402)