### PR TITLE
Add article: "Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1184,6 +1184,7 @@
     * [Applying Inaccessible Object Properties](knowledge/forge/exploits/applying-inaccessible-object-properties.md)
 * [Scripting](knowledge/scripting/README.md)
   * [Guides and Info](knowledge/scripting/guides-and-info/README.md)
+    * ["Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller](knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md)
     * [Creating an Equipment Object Reference with Mode Scripting](knowledge/scripting/guides-and-info/creating-an-equipment-object-reference-with-mode-scripting.md)
     * [Patterns](knowledge/scripting/guides-and-info/patterns/README.md)
       * [Telefragging](knowledge/scripting/guides-and-info/patterns/telefragging.md)

--- a/knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md
+++ b/knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md
@@ -1,0 +1,48 @@
+---
+description: >-
+  The Killed Unit Position pin in the On AI Unit Killed node outputs a
+  Vector3 that is 10x smaller than the actual Forge position.
+---
+
+# "Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller
+
+<figure><img src="../../../.gitbook/assets/cover-tsg-placeholder.jpg" alt="Cover image"><figcaption></figcaption></figure>
+
+Users may encounter spatial inaccuracies when attempting to use the position data from the `On AI Unit Killed` node, as the coordinate values do not match standard Forge scaling.
+
+## Coordinate Scaling Discrepancy
+
+The `Killed Unit Position` pin in the `On AI Unit Killed` node outputs a `Vector3` that is 10x smaller than the actual position values used by Forge. This discrepancy means that if the raw output is used directly for spawning effects or moving objects, the coordinates will be incorrect.
+
+<figure><img src="../../../.gitbook/assets/2025-12-17_HaloInfinite-d8mD.png" alt="Node setup"><figcaption><p>The node graph demonstrates the connection between the On AI Unit Killed node and a Scale Vector node.</p></figcaption></figure>
+
+### Impact on Spatial Logic
+
+Because the vector is scaled down, any logic relying on this position will place objects or effects at a location far from the intended event if the vector is not corrected.
+
+## Correcting the Output
+
+To obtain the correct position used by Forge, the output from the `Killed Unit Position` pin must be adjusted through additional nodes.
+
+### Required Node Configuration
+
+To resolve the scaling issue, the following configuration is required:
+
+* Feed the `Vector3` from the `Killed Unit Position` pin into a `Scale Vector` node.
+* Set the `Scalar` input of the `Scale Vector` node to `10.00`.
+
+{% hint style="warning" %}
+The `Killed Unit Position` pin must always be fed into a `Scale Vector` node with a `10.00` scalar to ensure the resulting position is accurate.
+{% endhint %}
+
+<figure><img src="../../../.gitbook/assets/2025-12-17_HaloInfinite-lcEr.jpg" alt="Debug output"><figcaption><p>Debug text displays the difference between the original and expected death positions.</p></figcaption></figure>
+
+***
+
+## Source Data
+
+* Discord thread: ["Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller](https://discord.com/channels/220766496635224065/1450874812405645402/1450874812405645402)
+
+#### <mark style="color:green;">Contributors</mark>
+
+Okom


### PR DESCRIPTION
Article draft generated by The Archivist:

- Article path: [knowledge/scripting/guides-and-info/killed-unit-position-pin-in-on-ai-unit-killed-node-is-scaled-10x-smaller.md](https://github.com/The-Scripters-Guild/ForgeWiki/pull/116/changes/d8d6c6c28a74f19f4d38b0287b1d81028a61b38f#diff-2a9423dd63646ed936d079d59273d0811b5caebe477f238838eca492442907e3)
- Source thread: ["Killed Unit Position" Pin in On AI Unit Killed Node is Scaled 10x Smaller](https://discord.com/channels/220766496635224065/1450874812405645402/1450874812405645402)