### PR TITLE
Update article: Object Limits

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -220,7 +220,7 @@
     * [Free For All](forge/standards/mode-setup/free-for-all.md)
   * [Map Requirements](forge/standards/map-requirements.md)
 
-  * [Object Limit and Telescoping Object Research](forge/standards/object-limit-and-telescoping-object-research.md)
+  * [Object Limits](forge/standards/object-limits.md)
 ## Scripting
 
 * [Scripting Basics and UI](scripting/scripting-basics-and-ui/README.md)

--- a/forge/standards/object-limits.md
+++ b/forge/standards/object-limits.md
@@ -4,7 +4,7 @@ description: >-
   and Static Geometry budgets and the impact of telescoping objects.
 ---
 
-# Object Limit and Telescoping Object Research
+# Object Limits
 
 <figure><img src="../../.gitbook/assets/cover-tsg-placeholder.jpg" alt="Cover image"><figcaption></figcaption></figure>
 


### PR DESCRIPTION
Article updated by The Archivist:

- Article path: [forge/standards/object-limits.md](https://github.com/The-Scripters-Guild/ForgeWiki/pull/133/changes/b3b40bb377ecaf4b113a20a0a3cabe7e5278359f#diff-1f6e8fd1fa7e4dc28e0cd603be156df59d73dbb5980a3622db14311e3978792b)
- Source thread: [Object Limit and Telescoping Object Research](https://discord.com/channels/220766496635224065/1434256456345059328/1434256456345059328)