### PR TITLE
Update article: Set Team Filter On Object

### DIFF
--- a/scripting/nodes/objects-filters/set-team-filter-on-object.md
+++ b/scripting/nodes/objects-filters/set-team-filter-on-object.md
@@ -1,25 +1,51 @@
+---
+description: >-
+  Restricts object interaction to a specific team or prevents a
+  specific team from interacting.
+---
+
 # Set Team Filter On Object
-![](../../../.gitbook/assets/set-team-filter-on-object.png)
+
+<figure><img src="../../../.gitbook/assets/cover-tsg-placeholder.jpg" alt="Cover image"><figcaption></figcaption></figure>
+
+This node applies a team-based restriction to a specific object, determining which teams are permitted to interact with it. If the `Invert` input is enabled, the specified team is blocked from interacting instead.
+
 ## Description
-Adds a filter to the Object that only allows the specified Team to interact with the object. If Inverted, the object cannot be interacted with by this Team; filters must be reapplied to objects that are respawned.
+Adds a filter to the Object that only allows the specified [Team](../variables-basic/team.md) to interact with the object. If Inverted, the object cannot be interacted with by this `Team`; filters must be reapplied to objects that are respawned.
 
 ## Node Type
 Nodes fall into two basic categories: Data and Execution. This node Executes a function directly in the node string.
 
 ## Inputs
 | Input | Type | Required | Description |
-|------------------|------------------|----------|--------------------------------------------------------------|
+|------------------|------------------|----------|--------------------------------------------|
 | Object | Object | Yes | Object to set filter on for team. |
 | Team | Team | Yes | Team to set filter for. |
 | Invert | Boolean | Yes | If TRUE, team cannot access object. If FALSE, team can access object. |
 
 ## Outputs
 | Output | Type | Description |
-|------------------|------------------|--------------------------------------------------------------|
+|------------------|------------------|--------------------------------------------------------|
 | (none) | | |
 
-\
-\
-**Contributors**
+{% warning %}
+Certain objects and interactions may bypass or exhibit unexpected behavior when team filters are applied.
+{% endwarning %}
 
-AddiCt3d 2CHa0s
+### Bypassed Objects
+The following objects do not appear to respect the team filter:
+* Ammo Crates
+* Scriptable Switches (including Invisible, Banished Terminal, Banished Touchpanel, Banished Touchpanel Wall, Forerunner Terminal, Forerunner Terminal Worn, and UNSC Console)
+* Power Sockets (including UNSC, UNSC Green Sand, UNSC Engine Blue, UNSC Engine Red, and UNSC Engine Yellow variants)
+
+### Other Behaviors
+* **Weapons:** Players can still perform refill pickups on weapons even if a filter is applied.
+* **Hacking Terminals:** The filter functions, but there is no interact button when no filter is on.
+## Source Data
+
+* Discord thread: [Object Filters have limitations](https://discord.com/channels/220766496635224065/1321416792643604551/1321416792643604551)
+
+#### <mark style="color:green;">Contributors</mark>
+
+AddiCt3d 2CHa0s\
+Artifice


### PR DESCRIPTION
Article updated by The Archivist:

- Article path: [scripting/nodes/objects-filters/set-team-filter-on-object.md](https://github.com/The-Scripters-Guild/ForgeWiki/pull/169/changes/98006668ee5fb64e5927e3ed1d3db7d71e0095c7#diff-c3e039c3069077c272f4b3ca09294109df4a03452f4243ebd5b165df129fe02f)
- Source thread: [Object Filters have limitations](https://discord.com/channels/220766496635224065/1321416792643604551/1321416792643604551)